### PR TITLE
Only invoke weak-modules if available

### DIFF
--- a/rpm/msr-safe.spec
+++ b/rpm/msr-safe.spec
@@ -64,7 +64,9 @@ exit 0
 
 %post
 /usr/bin/udevadm control --reload-rules
-echo /lib/modules/%{latest_kernel}/extra/msr-safe/msr-safe.ko | weak-modules --add-modules
+if which weak-modules >/dev/null 2>&1; then
+    echo /lib/modules/%{latest_kernel}/extra/msr-safe/msr-safe.ko | weak-modules --add-modules
+fi
 /usr/bin/systemctl daemon-reload >/dev/null 2>&1
 /usr/bin/systemctl enable msr-safe >/dev/null 2>&1 || :
 
@@ -73,7 +75,9 @@ if [ $1 -eq 0 ] ; then
     /usr/bin/systemctl stop msr-safe >/dev/null 2>&1
     /usr/bin/systemctl disable msr-safe >/dev/null 2>&1
 fi
-echo /lib/modules/%{latest_kernel}/extra/msr-safe/msr-safe.ko | weak-modules --remove-modules
+if which weak-modules >/dev/null 2>&1; then
+    echo /lib/modules/%{latest_kernel}/extra/msr-safe/msr-safe.ko | weak-modules --remove-modules
+fi
 
 %postun
 if [ "$1" -ge "1" ] ; then


### PR DESCRIPTION
- Resolves uninstallation issues on systems where the `weak-modules` command is not available.
- Resolves #89.