### PR TITLE
Fixes -Wmissing-attributes warnings.

### DIFF
--- a/msr_entry.c
+++ b/msr_entry.c
@@ -45,6 +45,21 @@
 #include "msr_allowlist.h"
 #include "msr_version.h"
 
+
+#if __GNUC__ >= 9 && LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
+#undef module_init
+#define module_init(initfn) \
+    static inline initcall_t __maybe_unused __inittest(void) \
+    { return initfn; } \
+    int init_module(void) __attribute__((__copy__(initfn))) __attribute__((alias(#initfn)));
+#undef module_exit
+#define module_exit(exitfn) \
+    static inline exitcall_t __maybe_unused __exittest(void) \
+    { return exitfn; } \
+    void cleanup_module(void) __attribute__((__copy__(exitfn))) __attribute__((alias(#exitfn)));
+#endif
+
+
 static struct class *msr_class;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
 static enum cpuhp_state cpuhp_msr_state;


### PR DESCRIPTION
Fixes #135 

gcc v9.0 made -Wmissing-attributes more strict, and as a result the #defines around module_init() and cleanup_module() started generating warnings.  The #defines were fixed around kernel 5.0.

This PR #undefs those two symbols and #defines them according to this patch:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0b999ae3614d09d97a1575936bcee884f912b10e

Not tested for icc or clang.